### PR TITLE
FIX: error in strict mode

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -70,7 +70,7 @@ module nyMdIcons {
       }
     };
   }
-
+  NyMdIcon.$inject = ["nyMdIcon"];
   angular
     .module('nyMdIcons')
     .directive('nyMdIcon', NyMdIcon);


### PR DESCRIPTION
ERROR: NyMdIcon is not using explicit annotation and cannot be invoked in strict mode